### PR TITLE
consistency between usermeta keys whether linking or registering

### DIFF
--- a/hm-accounts.sso.twitter.php
+++ b/hm-accounts.sso.twitter.php
@@ -275,10 +275,10 @@ class HMA_SSO_Twitter extends HMA_SSO_Provider {
 			return new WP_Error( 'sso-provider-already-linked' );
 		}
 		
-		update_user_meta( get_current_user_id(), '_twitter_oauth_token', $this->access_token['oauth_token'] );
+		update_user_meta( get_current_user_id(), '_twitter_oauth_token', $this->access_token );
 		update_user_meta( get_current_user_id(), '_twitter_oauth_token_secret', $this->access_token['oauth_token_secret'] );
 		
-		update_user_meta( get_current_user_id(), '_twitter_access_token', $this->access_token );
+		update_user_meta( get_current_user_id(), '_twitter_access_token', $this->access_token['oauth_token']] );
 		update_user_meta( get_current_user_id(), '_twitter_uid', $info->id );
 		
 		hm_success_message( 'Successfully connected the Twitter account "' . $info->screen_name . '" with your profile.', 'update-user' );


### PR DESCRIPTION
The usermeta keys for `oauth_token` and `access_key` are misnamed and used inconsistently in the twitter oauth class. Sometimes `_twitter_oauth_token` is a string (the `oauth_token` itself) and sometimes it's an array (the `access_key`, which contains the token and secret).

Confusingly, the code expects `_twitter_oauth_token` to always contain the `access_key`! If it's just a string - which you'd be forgiven for thinking it was - the connection will always fail when set_user() attempts to connect to twitter using the following code:

```
$this->access_token = get_user_meta( $this->user->ID, '_twitter_oauth_token', true ); 
$this->client = new TwitterOAuth( $this->api_key ,  $this->consumer_secret, $this->access_token['oauth_token'], $this->access_token['oauth_token_secret']);
```

You can see the problem in `link()`, where it says

```
update_user_meta( get_current_user_id(), '_twitter_oauth_token', $this->access_token['oauth_token'] );
/* ... */
update_user_meta( get_current_user_id(), '_twitter_access_token', $this->access_token );

```

and in `update_user_twitter_information()`, called by `register()` and `login()`, where it says:

```
update_user_meta( $this->user->ID, '_twitter_oauth_token', $this->access_token );
update_user_meta( $this->user->ID, '_twitter_access_token', $this->access_token['oauth_token'] );
```

This P.R. changes the keys in `link()` so they match up with the others. apologies for misnamed commit (s/postmeta/usermeta/g)
