### PR TITLE
Prevent error notices by passing both arguments that are present in the `wp_login` action

### DIFF
--- a/hm-accounts.classes.php
+++ b/hm-accounts.classes.php
@@ -95,7 +95,7 @@ class HM_Accounts {
 			}
 		}
 
-		$user = get_userdata( $user_id );
+		$user = get_user_by( 'id', $user_id );
 
 		// Send Notifcation email if specified
 		if ( $args['send_email'] )


### PR DESCRIPTION
See https://github.com/humanmade/WP-Remote-WordPress-Plugin/issues/105
