### PR TITLE
Update the Facebook SDK github url

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "facebook-sdk"]
 	path = facebook-sdk
-	url = https://github.com/facebook/php-sdk.git
+	url = https://github.com/facebook/facebook-php-sdk.git


### PR DESCRIPTION
It's changed from facebook/php-sdk to facebook/facebook-php-sdk
